### PR TITLE
feat!: allow custom telemetry tags to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ Example:
 ```hcl
 module "alz" {
   source = "Azure/terraform-azurerm-avm-ptn-alz/azurerm"
+
   # the key format is `management group id/policy assignment name`
   parent_id_overrides = {
     policy_definitions = {
@@ -573,20 +574,6 @@ object({
 ```
 
 Default: `{}`
-
-### <a name="input_partner_id"></a> [partner\_id](#input\_partner\_id)
-
-Description: A value to be included in the telemetry tag. Requires the `enable_telemetry` variable to be set to `true`. The must be in the following format:
-
-`<PARTNER_ID_UUID>:<PARTNER_DATA_UUID>`
-
-e.g.
-
-`00000000-0000-0000-0000-000000000000:00000000-0000-0000-0000-000000000000`
-
-Type: `string`
-
-Default: `null`
 
 ### <a name="input_policy_assignment_non_compliance_message_settings"></a> [policy\_assignment\_non\_compliance\_message\_settings](#input\_policy\_assignment\_non\_compliance\_message\_settings)
 
@@ -879,6 +866,25 @@ map(object({
 ```
 
 Default: `{}`
+
+### <a name="input_telemetry_additional_content"></a> [telemetry\_additional\_content](#input\_telemetry\_additional\_content)
+
+Description: Additional content to add to the telemetry tags. This can be used to add custom tags to the telemetry data.
+
+Any information entered here will be sent to Microsoft as part of the telemetry data collected. Do not include any personal or sensitive information.
+
+e.g.
+
+```hcl
+telemetry_additional_content = {
+  custom_tag_1 = "value1"
+  custom_tag_2 = "value2"
+}
+```
+
+Type: `any`
+
+Default: `null`
 
 ### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
 

--- a/main.telemetry_override.tf
+++ b/main.telemetry_override.tf
@@ -15,16 +15,18 @@ resource "random_uuid" "telemetry" {
 resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
-  tags = merge({
-    subscription_id        = one(data.azapi_client_config.telemetry).subscription_id
-    tenant_id              = one(data.azapi_client_config.telemetry).tenant_id
-    module_source          = one(data.modtm_module_source.telemetry).module_source
-    module_version         = one(data.modtm_module_source.telemetry).module_version
-    random_id              = one(random_uuid.telemetry).result
-    location               = local.main_location
-    alz_library_references = jsonencode(one(data.alz_metadata.telemetry).alz_library_references)
+  tags = merge(
+    # Add additional tags first so the AVM tags take precedence..
+    var.telemetry_additional_content,
+    {
+      subscription_id        = one(data.azapi_client_config.telemetry).subscription_id
+      tenant_id              = one(data.azapi_client_config.telemetry).tenant_id
+      module_source          = one(data.modtm_module_source.telemetry).module_source
+      module_version         = one(data.modtm_module_source.telemetry).module_version
+      random_id              = one(random_uuid.telemetry).result
+      location               = local.main_location
+      alz_library_references = jsonencode(one(data.alz_metadata.telemetry).alz_library_references)
     },
-    var.partner_id != null ? { partner_id = var.partner_id } : {}
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -338,7 +338,7 @@ Example:
 ```hcl
 module "alz" {
   source = "Azure/terraform-azurerm-avm-ptn-alz/azurerm"
-  
+
   # the key format is `management group id/policy assignment name`
   parent_id_overrides = {
     policy_definitions = {
@@ -349,25 +349,6 @@ module "alz" {
 ```
 DESCRIPTION
   nullable    = false
-}
-
-variable "partner_id" {
-  type        = string
-  default     = null
-  description = <<DESCRIPTION
-A value to be included in the telemetry tag. Requires the `enable_telemetry` variable to be set to `true`. The must be in the following format:
-
-`<PARTNER_ID_UUID>:<PARTNER_DATA_UUID>`
-
-e.g.
-
-`00000000-0000-0000-0000-000000000000:00000000-0000-0000-0000-000000000000`
-DESCRIPTION
-
-  validation {
-    error_message = "The partner id must be in the format <PARTNER_ID_UUID>:<PARTNER_DATA_UUID>. All letters must be lowercase"
-    condition     = var.partner_id == null ? true : can(regex("^[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}:[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}$", var.partner_id))
-  }
 }
 
 variable "policy_assignment_non_compliance_message_settings" {
@@ -621,6 +602,29 @@ DESCRIPTION
   validation {
     error_message = "All subscription ids must be valid UUIDs."
     condition     = alltrue([for v in var.subscription_placement : can(regex("^[a-f\\d]{4}(?:[a-f\\d]{4}-){4}[a-f\\d]{12}$", v.subscription_id))])
+  }
+}
+
+variable "telemetry_additional_content" {
+  type        = any
+  default     = null
+  description = <<DESCRIPTION
+Additional content to add to the telemetry tags. This can be used to add custom tags to the telemetry data.
+
+Any information entered here will be sent to Microsoft as part of the telemetry data collected. Do not include any personal or sensitive information.
+
+e.g.
+
+```hcl
+telemetry_additional_content = {
+  custom_tag_1 = "value1"
+  custom_tag_2 = "value2"
+}
+DESCRIPTION
+
+  validation {
+    error_message = "The telemetry_additional_content variable must be a map/object."
+    condition     = var.telemetry_additional_content == null || can(merge({}, var.telemetry_additional_content))
   }
 }
 


### PR DESCRIPTION
This pull request updates the telemetry tagging mechanism to allow users to add custom telemetry tags via a new variable, and removes the previously used `partner_id` variable. The changes improve flexibility for telemetry customization and simplify the configuration interface.

**Telemetry Tagging Improvements:**

* Added a new variable `telemetry_additional_content` that allows users to provide custom tags for telemetry data. This variable is validated to ensure it is a map/object and is documented in both `variables.tf` and `README.md`. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR608-R630) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R870-R888)
* Updated the `modtm_telemetry` resource in `main.telemetry_override.tf` to merge any custom tags from `telemetry_additional_content` with the default AVM tags, ensuring AVM tags take precedence if there are conflicts.

**Removal of Deprecated Configuration:**

* Removed the `partner_id` variable, its validation, and all related documentation from `variables.tf` and `README.md`, streamlining the telemetry configuration. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL354-L372) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L577-L590) [[3]](diffhunk://#diff-46505128ca55dff3ca428df4e83de976f5d9191bec152069d45980283d061d44L27)

**Documentation Updates:**

* Updated the `README.md` example and variable documentation to reflect the new telemetry tagging approach and remove references to `partner_id`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R555) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R870-R888) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L577-L590)