### PR TITLE
feat!: replace resource_api_versions with resource_types

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,22 +710,39 @@ Type: `any`
 
 Default: `null`
 
-### <a name="input_resource_api_versions"></a> [resource\_api\_versions](#input\_resource\_api\_versions)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: EXPERIMENTAL: Modify this to change the API versions used for each resource type. Added to support clouds with different API versions, e.g. US Government.
+Description: A map of full AzAPI resource type strings (`<provider>/<resource>@<api-version>`) used by this module.
 
-Modifying these values may result in unexpected behavior or compatibility issues, which we cannot test for. Please do not raise issues against this module if you change these values.
+Override an entry to change the casing or API version of the corresponding resource type. This is useful for sovereign clouds that need different API versions (e.g. US Government), or to work around AzAPI casing inconsistencies between create and read responses (for example, providing `Microsoft.Authorization/RoleDefinitions@2022-04-01` to mitigate inconsistent-result errors from the upstream provider).
+
+Modifying these values may produce unexpected behavior or compatibility issues which we cannot test for. Please do not raise issues against this module if you change these values.
+
+Keys:
+
+- `management_group` - Defaults to `Microsoft.Management/managementGroups@2023-04-01`.
+- `management_group_settings` - Defaults to `Microsoft.Management/managementGroups/settings@2023-04-01`.
+- `management_group_subscription` - Defaults to `Microsoft.Management/managementGroups/subscriptions@2023-04-01`.
+- `policy_assignment` - Defaults to `Microsoft.Authorization/policyAssignments@2024-04-01`.
+- `policy_definition` - Defaults to `Microsoft.Authorization/policyDefinitions@2023-04-01`.
+- `policy_set_definition` - Defaults to `Microsoft.Authorization/policySetDefinitions@2023-04-01`.
+- `role_assignment` - Defaults to `Microsoft.Authorization/roleAssignments@2022-04-01`.
+- `role_definition` - Defaults to `Microsoft.Authorization/roleDefinitions@2022-04-01`.
+- `user_assigned_identity` - Defaults to `Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31`.
 
 Type:
 
 ```hcl
 object({
-    policy_assignment     = optional(string, "2024-04-01")
-    policy_definition     = optional(string, "2023-04-01")
-    policy_set_definition = optional(string, "2023-04-01")
-    role_assignment       = optional(string, "2022-04-01")
-    role_definition       = optional(string, "2022-04-01")
-    management_group      = optional(string, "2023-04-01")
+    management_group              = optional(string, "Microsoft.Management/managementGroups@2023-04-01")
+    management_group_settings     = optional(string, "Microsoft.Management/managementGroups/settings@2023-04-01")
+    management_group_subscription = optional(string, "Microsoft.Management/managementGroups/subscriptions@2023-04-01")
+    policy_assignment             = optional(string, "Microsoft.Authorization/policyAssignments@2024-04-01")
+    policy_definition             = optional(string, "Microsoft.Authorization/policyDefinitions@2023-04-01")
+    policy_set_definition         = optional(string, "Microsoft.Authorization/policySetDefinitions@2023-04-01")
+    role_assignment               = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    role_definition               = optional(string, "Microsoft.Authorization/roleDefinitions@2022-04-01")
+    user_assigned_identity        = optional(string, "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31")
   })
 ```
 

--- a/main.hierarchy_settings.tf
+++ b/main.hierarchy_settings.tf
@@ -5,7 +5,7 @@ resource "azapi_resource" "hierarchy_settings" {
 
   name      = "default"
   parent_id = local.tenant_root_group_resource_id
-  type      = "Microsoft.Management/managementGroups/settings@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group_settings
   body = {
     properties = {
       defaultManagementGroup               = provider::azapi::tenant_resource_id("Microsoft.Management/managementGroups", [var.management_group_hierarchy_settings.default_management_group_name])
@@ -32,7 +32,7 @@ resource "azapi_update_resource" "hierarchy_settings" {
 
   name      = "default"
   parent_id = local.tenant_root_group_resource_id
-  type      = "Microsoft.Management/managementGroups/settings@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group_settings
   body = {
     properties = {
       defaultManagementGroup               = provider::azapi::tenant_resource_id("Microsoft.Management/managementGroups", [var.management_group_hierarchy_settings.default_management_group_name])

--- a/main.management_groups.tf
+++ b/main.management_groups.tf
@@ -7,7 +7,7 @@ resource "azapi_resource" "management_groups_level_0" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {
@@ -52,7 +52,7 @@ resource "azapi_resource" "management_groups_level_1" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {
@@ -94,7 +94,7 @@ resource "azapi_resource" "management_groups_level_2" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {
@@ -136,7 +136,7 @@ resource "azapi_resource" "management_groups_level_3" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {
@@ -178,7 +178,7 @@ resource "azapi_resource" "management_groups_level_4" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {
@@ -220,7 +220,7 @@ resource "azapi_resource" "management_groups_level_5" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {
@@ -262,7 +262,7 @@ resource "azapi_resource" "management_groups_level_6" {
 
   name      = each.value.id
   parent_id = "/"
-  type      = "Microsoft.Management/managementGroups@${var.resource_api_versions.management_group}"
+  type      = var.resource_types.management_group
   body = {
     properties = {
       details = {

--- a/main.policy_assignments.tf
+++ b/main.policy_assignments.tf
@@ -8,7 +8,7 @@ resource "azapi_resource" "policy_assignments" {
   location  = var.location
   name      = each.value.assignment.name
   parent_id = "${coalesce(lookup(var.parent_id_overrides.policy_assignments, each.key, null), "/providers/Microsoft.Management/managementGroups")}/${each.value.mg}"
-  type      = "Microsoft.Authorization/policyAssignments@${var.resource_api_versions.policy_assignment}"
+  type      = var.resource_types.policy_assignment
   body = {
     properties = {
       description       = lookup(each.value.assignment.properties, "description", null)

--- a/main.policy_definitions.tf
+++ b/main.policy_definitions.tf
@@ -3,7 +3,7 @@ resource "azapi_resource" "policy_definitions" {
 
   name      = each.value.definition.name
   parent_id = "${coalesce(lookup(var.parent_id_overrides.policy_definitions, each.key, null), "/providers/Microsoft.Management/managementGroups")}/${each.value.mg}"
-  type      = "Microsoft.Authorization/policyDefinitions@${var.resource_api_versions.policy_definition}"
+  type      = var.resource_types.policy_definition
   body = {
     properties = each.value.definition.properties
   }

--- a/main.policy_role_assignments.tf
+++ b/main.policy_role_assignments.tf
@@ -6,7 +6,7 @@ data "azapi_resource" "policy_user_assigned_identities" {
   for_each = local.policy_assignments_user_assigned_identity
 
   resource_id = each.value[0]
-  type        = "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31"
+  type        = var.resource_types.user_assigned_identity
   response_export_values = [
     "properties.principalId",
   ]
@@ -22,7 +22,7 @@ resource "azapi_resource" "policy_role_assignments" {
 
   name      = each.key
   parent_id = each.value.scope
-  type      = "Microsoft.Authorization/roleAssignments@${var.resource_api_versions.role_assignment}"
+  type      = var.resource_types.role_assignment
   body = {
     properties = {
       principalId      = each.value.principal_id

--- a/main.policy_set_definitions.tf
+++ b/main.policy_set_definitions.tf
@@ -3,7 +3,7 @@ resource "azapi_resource" "policy_set_definitions" {
 
   name      = each.value.set_definition.name
   parent_id = "${coalesce(lookup(var.parent_id_overrides.policy_set_definitions, each.key, null), "/providers/Microsoft.Management/managementGroups")}/${each.value.mg}"
-  type      = "Microsoft.Authorization/policySetDefinitions@${var.resource_api_versions.policy_set_definition}"
+  type      = var.resource_types.policy_set_definition
   body = {
     properties = each.value.set_definition.properties
   }

--- a/main.role_assignments.tf
+++ b/main.role_assignments.tf
@@ -28,7 +28,7 @@ resource "azapi_resource" "management_group_role_assignments" {
 
   name                   = each.value.role_assignments_azapi.this.name
   parent_id              = provider::azapi::tenant_resource_id("Microsoft.Management/managementGroups", [var.management_group_role_assignments[each.key].management_group_name])
-  type                   = "Microsoft.Authorization/roleAssignments@${var.resource_api_versions.role_assignment}"
+  type                   = var.resource_types.role_assignment
   body                   = each.value.role_assignments_azapi.this.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.role_definitions.tf
+++ b/main.role_definitions.tf
@@ -3,7 +3,7 @@ resource "azapi_resource" "role_definitions" {
 
   name      = each.value.role_definition.name
   parent_id = "${coalesce(lookup(var.parent_id_overrides.role_definitions, each.key, null), "/providers/Microsoft.Management/managementGroups")}/${each.value.mg}"
-  type      = "Microsoft.Authorization/roleDefinitions@${var.resource_api_versions.role_definition}"
+  type      = var.resource_types.role_definition
   body = {
     properties = {
       assignableScopes = each.value.role_definition.properties.assignableScopes

--- a/main.subscription_placement.tf
+++ b/main.subscription_placement.tf
@@ -3,7 +3,7 @@ resource "azapi_resource" "subscription_placement" {
 
   name                   = each.value.subscription_id
   parent_id              = "/providers/Microsoft.Management/managementGroups/${each.value.management_group_name}"
-  type                   = "Microsoft.Management/managementGroups/subscriptions@2023-04-01"
+  type                   = var.resource_types.management_group_subscription
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -33,7 +33,7 @@ resource "azapi_resource_action" "subscription_placement_create" {
 
   method                 = "PUT"
   resource_id            = "/providers/Microsoft.Management/managementGroups/${each.value.management_group_name}/subscriptions/${each.value.subscription_id}"
-  type                   = "Microsoft.Management/managementGroups/subscriptions@2023-04-01"
+  type                   = var.resource_types.management_group_subscription
   headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry = var.retries.subscription_placement.error_message_regex != null ? {
@@ -61,7 +61,7 @@ resource "azapi_resource_action" "subscription_placement_delete" {
 
   method                 = "PUT"
   resource_id            = "/providers/Microsoft.Management/managementGroups/${local.subscription_placement_destroy_management_group_id}/subscriptions/${each.value.subscription_id}"
-  type                   = "Microsoft.Management/managementGroups/subscriptions@2023-04-01"
+  type                   = var.resource_types.management_group_subscription
   headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry = var.retries.subscription_placement.error_message_regex != null ? {

--- a/tests/unit/resourcetypes.tftest.hcl
+++ b/tests/unit/resourcetypes.tftest.hcl
@@ -1,0 +1,115 @@
+mock_provider "alz" {}
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+
+variables {
+  management_group_hierarchy_settings = {
+    default_management_group_name            = "test"
+    require_authorization_for_group_creation = true
+    update_existing                          = false
+  }
+  parent_resource_id = "test"
+  location           = "test"
+  architecture_name  = "test"
+}
+
+run "defaults" {
+  command = plan
+
+  assert {
+    condition     = var.resource_types.management_group == "Microsoft.Management/managementGroups@2023-04-01"
+    error_message = "Default management_group type should be Microsoft.Management/managementGroups@2023-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.management_group_settings == "Microsoft.Management/managementGroups/settings@2023-04-01"
+    error_message = "Default management_group_settings type should be Microsoft.Management/managementGroups/settings@2023-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.management_group_subscription == "Microsoft.Management/managementGroups/subscriptions@2023-04-01"
+    error_message = "Default management_group_subscription type should be Microsoft.Management/managementGroups/subscriptions@2023-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.policy_assignment == "Microsoft.Authorization/policyAssignments@2024-04-01"
+    error_message = "Default policy_assignment type should be Microsoft.Authorization/policyAssignments@2024-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.policy_definition == "Microsoft.Authorization/policyDefinitions@2023-04-01"
+    error_message = "Default policy_definition type should be Microsoft.Authorization/policyDefinitions@2023-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.policy_set_definition == "Microsoft.Authorization/policySetDefinitions@2023-04-01"
+    error_message = "Default policy_set_definition type should be Microsoft.Authorization/policySetDefinitions@2023-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.role_assignment == "Microsoft.Authorization/roleAssignments@2022-04-01"
+    error_message = "Default role_assignment type should be Microsoft.Authorization/roleAssignments@2022-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.role_definition == "Microsoft.Authorization/roleDefinitions@2022-04-01"
+    error_message = "Default role_definition type should be Microsoft.Authorization/roleDefinitions@2022-04-01."
+  }
+
+  assert {
+    condition     = var.resource_types.user_assigned_identity == "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31"
+    error_message = "Default user_assigned_identity type should be Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31."
+  }
+
+  assert {
+    condition     = azapi_resource.hierarchy_settings[0].type == "Microsoft.Management/managementGroups/settings@2023-04-01"
+    error_message = "The default management_group_settings type should be applied to the hierarchy_settings resource."
+  }
+}
+
+run "override_propagates_to_resource" {
+  command = plan
+
+  variables {
+    resource_types = {
+      management_group_settings = "Microsoft.Management/managementGroups/settings@2020-05-01"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.hierarchy_settings[0].type == "Microsoft.Management/managementGroups/settings@2020-05-01"
+    error_message = "Overriding var.resource_types.management_group_settings should change the type argument on azapi_resource.hierarchy_settings."
+  }
+
+  assert {
+    condition     = var.resource_types.management_group == "Microsoft.Management/managementGroups@2023-04-01"
+    error_message = "Unspecified keys in var.resource_types must keep their default values."
+  }
+}
+
+run "casing_override_for_issue_4165" {
+  command = plan
+
+  variables {
+    resource_types = {
+      role_definition = "Microsoft.Authorization/RoleDefinitions@2022-04-01"
+    }
+  }
+
+  assert {
+    condition     = var.resource_types.role_definition == "Microsoft.Authorization/RoleDefinitions@2022-04-01"
+    error_message = "var.resource_types must accept casing overrides for AzAPI types (mitigation for Azure/Azure-Landing-Zones#4165)."
+  }
+}
+
+run "invalid_type_string_rejected" {
+  command = plan
+
+  variables {
+    resource_types = {
+      role_definition = "Microsoft.Authorization/roleDefinitions"
+    }
+  }
+
+  expect_failures = [var.resource_types]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -482,22 +482,44 @@ policy_role_assignments_dependencies = [
 DESCRIPTION
 }
 
-variable "resource_api_versions" {
+variable "resource_types" {
   type = object({
-    policy_assignment     = optional(string, "2024-04-01")
-    policy_definition     = optional(string, "2023-04-01")
-    policy_set_definition = optional(string, "2023-04-01")
-    role_assignment       = optional(string, "2022-04-01")
-    role_definition       = optional(string, "2022-04-01")
-    management_group      = optional(string, "2023-04-01")
+    management_group              = optional(string, "Microsoft.Management/managementGroups@2023-04-01")
+    management_group_settings     = optional(string, "Microsoft.Management/managementGroups/settings@2023-04-01")
+    management_group_subscription = optional(string, "Microsoft.Management/managementGroups/subscriptions@2023-04-01")
+    policy_assignment             = optional(string, "Microsoft.Authorization/policyAssignments@2024-04-01")
+    policy_definition             = optional(string, "Microsoft.Authorization/policyDefinitions@2023-04-01")
+    policy_set_definition         = optional(string, "Microsoft.Authorization/policySetDefinitions@2023-04-01")
+    role_assignment               = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    role_definition               = optional(string, "Microsoft.Authorization/roleDefinitions@2022-04-01")
+    user_assigned_identity        = optional(string, "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31")
   })
   default     = {}
   description = <<DESCRIPTION
-EXPERIMENTAL: Modify this to change the API versions used for each resource type. Added to support clouds with different API versions, e.g. US Government.
+A map of full AzAPI resource type strings (`<provider>/<resource>@<api-version>`) used by this module.
 
-Modifying these values may result in unexpected behavior or compatibility issues, which we cannot test for. Please do not raise issues against this module if you change these values.
+Override an entry to change the casing or API version of the corresponding resource type. This is useful for sovereign clouds that need different API versions (e.g. US Government), or to work around AzAPI casing inconsistencies between create and read responses (for example, providing `Microsoft.Authorization/RoleDefinitions@2022-04-01` to mitigate inconsistent-result errors from the upstream provider).
+
+Modifying these values may produce unexpected behavior or compatibility issues which we cannot test for. Please do not raise issues against this module if you change these values.
+
+Keys:
+
+- `management_group` - Defaults to `Microsoft.Management/managementGroups@2023-04-01`.
+- `management_group_settings` - Defaults to `Microsoft.Management/managementGroups/settings@2023-04-01`.
+- `management_group_subscription` - Defaults to `Microsoft.Management/managementGroups/subscriptions@2023-04-01`.
+- `policy_assignment` - Defaults to `Microsoft.Authorization/policyAssignments@2024-04-01`.
+- `policy_definition` - Defaults to `Microsoft.Authorization/policyDefinitions@2023-04-01`.
+- `policy_set_definition` - Defaults to `Microsoft.Authorization/policySetDefinitions@2023-04-01`.
+- `role_assignment` - Defaults to `Microsoft.Authorization/roleAssignments@2022-04-01`.
+- `role_definition` - Defaults to `Microsoft.Authorization/roleDefinitions@2022-04-01`.
+- `user_assigned_identity` - Defaults to `Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31`.
 DESCRIPTION
   nullable    = false
+
+  validation {
+    condition     = alltrue([for v in values(var.resource_types) : can(regex("^[^@]+@[^@]+$", v))])
+    error_message = "Each resource type must be a full AzAPI type string of the form `<provider>/<resource>@<api-version>`."
+  }
 }
 
 variable "retries" {


### PR DESCRIPTION
## Summary

Replaces `var.resource_api_versions` with `var.resource_types`, which exposes the **full** AzAPI type string (`<provider>/<resource>@<api-version>`) for every AzAPI resource managed by this module. This aligns the module with the AVM v1 Terraform spec proposed in Azure/Azure-Verified-Modules#2720 (TFFR6 — `resource_types` interface).

## Why

Issue Azure/Azure-Landing-Zones#4165 reports `Provider produced inconsistent result after apply` / `Unexpected Identity Change` errors because AzAPI returns a different casing (`RoleDefinitions` vs `roleDefinitions`) between the initial create and subsequent reads.

The previous `resource_api_versions` variable only let consumers override the API version portion of each type string. By exposing the full type string, consumers can:

- Work around the AzAPI casing bug locally (the workaround for #4165).
- Pin both the resource type **and** API version per Azure cloud (sovereign-cloud support).
- Override the previously hard-coded type strings for subscription placement, the user-assigned identity data source, and policy role assignments — TFFR6 forbids hard-coding AzAPI type strings.

## What changed

- **Added** `var.resource_types` in `variables.tf` — an object with 9 `optional(string, "...")` fields, defaults match the previously hard-coded type+version strings, with a regex validation rule (`^[^@]+@[^@]+$`) enforcing the `provider/resource@api-version` shape.
- **Removed** `var.resource_api_versions` from `variables.tf` (no soft-deprecation — consumers will get Terraform's standard "unsupported variable" error and must migrate).
- **Replaced** every `type =` argument across 9 `main.*.tf` files to source from `var.resource_types.<key>`, including 3 previously hard-coded strings.
- **Added** `tests/unit/resourcetypes.tftest.hcl` with 4 run blocks covering: defaults, override propagates into the AzAPI `type` argument, casing-override for #4165, and invalid type-string validation rejection.

| Key | Default type string |
| --- | --- |
| `management_group` | `Microsoft.Management/managementGroups@2023-04-01` |
| `management_group_settings` | `Microsoft.Management/managementGroups/settings@2023-04-01` |
| `management_group_subscription` | `Microsoft.Management/managementGroups/subscriptions@2023-04-01` |
| `policy_assignment` | `Microsoft.Authorization/policyAssignments@2024-04-01` |
| `policy_definition` | `Microsoft.Authorization/policyDefinitions@2023-04-01` |
| `policy_set_definition` | `Microsoft.Authorization/policySetDefinitions@2023-04-01` |
| `role_assignment` | `Microsoft.Authorization/roleAssignments@2022-04-01` |
| `role_definition` | `Microsoft.Authorization/roleDefinitions@2022-04-01` |
| `user_assigned_identity` | `Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31` |

## Breaking change

`var.resource_api_versions` has been **removed**. Consumers that previously set it (e.g. sovereign-cloud users pinning older API versions) must migrate to `var.resource_types` — see the variable description in `variables.tf` for the supported keys and default values.

Example migration:

```hcl
# Before
resource_api_versions = {
  role_definition = "2022-04-01"
}

# After
resource_types = {
  role_definition = "Microsoft.Authorization/roleDefinitions@2022-04-01"
}
```

## Validation

- `terraform fmt -recursive` — clean
- `./avm.ps1 pre-commit` — passed
- `./avm.ps1 tf-test-unit` — passed (including the new `resourcetypes` test)
- `./avm.ps1 pr-check` — local run failed **only** on `terraform plan` for examples that require Azure CLI auth from inside the docker container (`alz_architecture` fetches built-in policies). Repo CI should run these with its own service-principal auth.

## References

- Closes Azure/Azure-Landing-Zones#4165
- Refs Azure/Azure-Verified-Modules#2720 (AVM v1 spec — TFFR6)

---

Marked as draft until repo CI validates the auth-dependent example plans.